### PR TITLE
fix(deps): move pkg-utils to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,10 @@
   "dependencies": {
     "@actions/core": "^1.11.1",
     "@actions/github": "^6.0.0",
-    "@sanity/pkg-utils": "^6.12.2",
     "yaml": "^2.6.1"
   },
   "devDependencies": {
+    "@sanity/pkg-utils": "^6.12.2",
     "@sanity/prettier-config": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,13 +14,13 @@ importers:
       '@actions/github':
         specifier: ^6.0.0
         version: 6.0.0
-      '@sanity/pkg-utils':
-        specifier: ^6.12.2
-        version: 6.12.2(@types/node@22.10.2)(typescript@5.7.2)
       yaml:
         specifier: ^2.6.1
         version: 2.6.1
     devDependencies:
+      '@sanity/pkg-utils':
+        specifier: ^6.12.2
+        version: 6.12.2(@types/node@22.10.2)(typescript@5.7.2)
       '@sanity/prettier-config':
         specifier: ^1.0.3
         version: 1.0.3(prettier@3.4.2)


### PR DESCRIPTION
Should not be needed for anything but builds, right?