### PR TITLE
Add token support in ./action.yml

### DIFF
--- a/.github/workflows/test-action-with-token.yml
+++ b/.github/workflows/test-action-with-token.yml
@@ -1,0 +1,13 @@
+name: Test GitHub Action
+on: push
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate Sanity Template with GitHub Action
+        uses: sanity-io/template-validator@v2
+        with:
+          directory: "test/fixtures/npm-workspace-monorepo"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ inputs:
   directory:
     description: "The directory to validate"
     required: false
+  token:
+    description: "GitHub token for accessing and validating private repositories."
+    required: false
 runs:
   using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
### Description

Based on [this issue](https://github.com/sanity-io/template-validator/issues/11), when passing the token it was being marked as invalid. I did some digging and realised that this was never passed in at the root `./action.yml` file, so it was throwing an error.

I assume this was something that was missed, though I admit I don't have a deep understanding of this.

Hopefully it's of some use!

### What to review

Review line lines 7–8 in `./action.yml`

```yml
  token:
    description: "GitHub token for accessing and validating private repositories." # copied from the README
    required: false
``` 

### Testing

I tested this locally using `act`. I've added an additional test in `/.github/workflows/test-action-with-token.yml`.

```yml
name: Test GitHub Action
on: push

jobs:
  validate:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Validate Sanity Template with GitHub Action
        uses: ./ # temporarily used local action but the pushed code uses @v2
        with:
          directory: "test/fixtures/npm-workspace-monorepo"
          token: ${{ secrets.GITHUB_TOKEN }}
```

![Screenshot 2025-07-03 at 10 24 18 AM](https://github.com/user-attachments/assets/c6ef38ba-8afe-4d27-be54-32d5bacd09e3)
