### PR TITLE
perf: mark GitHub Actions dependencies as build-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
   "browserslist": "extends @sanity/browserslist-config",
   "prettier": "@sanity/prettier-config",
   "dependencies": {
-    "@actions/core": "^3.0.0",
-    "@actions/github": "^9.0.0",
     "yaml": "^2.6.1"
   },
   "devDependencies": {
+    "@actions/core": "^3.0.0",
+    "@actions/github": "^9.0.0",
     "@sanity/pkg-utils": "^7.1.1",
     "@sanity/prettier-config": "^1.0.3",
     "@sanity/semantic-release-preset": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,16 +8,16 @@ importers:
 
   .:
     dependencies:
+      yaml:
+        specifier: ^2.6.1
+        version: 2.8.2
+    devDependencies:
       '@actions/core':
         specifier: ^3.0.0
         version: 3.0.0
       '@actions/github':
         specifier: ^9.0.0
         version: 9.0.0
-      yaml:
-        specifier: ^2.6.1
-        version: 2.8.2
-    devDependencies:
       '@sanity/pkg-utils':
         specifier: ^7.1.1
         version: 7.11.9(@types/node@18.19.130)(typescript@5.9.3)


### PR DESCRIPTION
`@actions/core` and `@actions/github` are only needed during build, since they get bundled into an executable with ncc. This means we can mark them as dev deps, which means `@sanity/cli` users will no longer need to download the 9.6MB of OpenAPI types that are bundled with them 🥴